### PR TITLE
be crisp that we only need to communicate on TLS1.2

### DIFF
--- a/TrusonaSDK.HTTP/Client/ServiceFactory.cs
+++ b/TrusonaSDK.HTTP/Client/ServiceFactory.cs
@@ -7,6 +7,7 @@
 // Copyright (c) 2018 Trusona, Inc.
 using System;
 using System.Collections.Generic;
+using System.Net;
 using TrusonaSDK.HTTP.Client.Interceptor;
 using TrusonaSDK.HTTP.Client.V2.Service;
 
@@ -39,6 +40,8 @@ namespace TrusonaSDK.HTTP.Client
 
     public ServiceFactory(IConfiguration configuration, IHttpClientWrapper clientWrapper)
     {
+      ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
       this._configuration = configuration;
       this._clientWrapper = clientWrapper;
     }


### PR DESCRIPTION
we need to be crisp that we need to communicate on TLS 1.2
otherwise the underlying OS/framework will do TLS 1.0 😭 

